### PR TITLE
Fix this.ready.tap error.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+const Promise = require('bluebird')
 const AbstractClientStore = require('express-brute/lib/AbstractClientStore');
 
 const KnexStore = module.exports = function (options) {
@@ -30,6 +31,8 @@ const KnexStore = module.exports = function (options) {
                 });
             });
     }
+
+    this.ready = Promise.resolve(this.ready);
 };
 KnexStore.prototype = Object.create(AbstractClientStore.prototype);
 KnexStore.prototype.set = function (key, value, lifetime, callback) {


### PR DESCRIPTION
Closes #11

bluebird has been removed from knex 0.20+. So, I required `bluebird`.